### PR TITLE
Use EPYTHONPATH over PYTHONPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ If you wish to install it (into the bin directory) then sudo make install follow
 
 If you do not install it then you can still run epython from the current directory, as ./epython.sh but ensure that epython-device.elf is in the current directory when you run the interpreter. The epython.sh script will detect whether to run as sudo (earlier versions of the parallella OS) or not (later versions.)
 
-In order to include files (required for parallel functions) you must either run your Python codes in the same directory as the executables (and the modules directory) and/or export the PYTHONPATH environment variable to point to the modules directory. When including files, by default ePython will search in the current directory, any subdirectory called modules and then the PYTHONPATH variable, which follows the same syntax as the PATH variable.
+In order to include files (required for parallel functions) you must either run your Python codes in the same directory as the executables (and the modules directory) and/or export the EPYTHONPATH environment variable to point to the modules directory. When including files, by default ePython will search in the current directory, any subdirectory called modules and then the EPYTHONPATH variable, which follows the same syntax as the PATH variable.
 
-Issuing export export PYTHONPATH=$PYTHONPATH:`pwd` in the epython directory will set this to point to the current directory. You can also modify your ~/.bashrc file to contain a similiar command.
+Issuing export export EPYTHONPATH=$EPYTHONPATH:`pwd` in the epython directory will set this to point to the current directory. You can also modify your ~/.bashrc file to contain a similiar command.
 
 For more information about installing ePython refer [here](docs/tutorial1.md), for upgrading ePython refer [here](docs/installupgrade.md)
 

--- a/epython.sh
+++ b/epython.sh
@@ -6,7 +6,7 @@ ELIBS="${EPIPHANY_HOME}/tools/host/lib"
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${ELIBS}
 EHDF=/opt/adapteva/esdk/bsps/current/parallella_E16G3_1GB.hdf
 
-export PYTHONPATH=$PYTHONPATH:`pwd`
+export EPYTHONPATH=$EPYTHONPATH:`pwd`
 
 OS_MAJ="$(uname -a | cut -d' ' -f3 | cut -d'.' -f1)"
 OS_VER="$(uname -a | cut -d' ' -f3 | cut -d'.' -f2)"

--- a/host/main.c
+++ b/host/main.c
@@ -308,7 +308,7 @@ static char* getIncludeFileWithPath(char * filename) {
             free(testFilename);
 	    }
 
-		char * prev = getenv("PYTHONPATH");
+		char * prev = getenv("EPYTHONPATH");
 		if (prev == NULL) return NULL;
 		char * pch=strchr(prev, ':');
 		while (pch != NULL) {

--- a/makefile
+++ b/makefile
@@ -40,7 +40,7 @@ install:
 	@cp epython.sh $(DESTDIR)$(bindir)/epython
 	@mkdir -p $(DESTDIR)$(includedir)/epython
 	@cp -R modules $(DESTDIR)$(includedir)/epython/.
-	@echo 'export PYTHONPATH=$$PYTHONPATH:$(includedir)/epython/modules:$(shell pwd)' >> ~/.bashrc
+	@echo 'export EPYTHONPATH=$$EPYTHONPATH:$(includedir)/epython/modules:$(shell pwd)' >> ~/.bashrc
 	@echo "ePython installed, start a new bash session by executing bash before running ePython"
 
 uninstall:


### PR DESCRIPTION
It is really not a good idea to use PYTHONPATH as it can easily break
"normal" python.

Case in point:

```shell
$ python -i
Python 2.7.9 (default, Apr  2 2015, 16:04:32)
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import random
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/include/epython/modules/random.py", line 2
    return (native rtl_math(14) % (b-a)) + a
                          ^
SyntaxError: invalid syntax
>>>
```

Signed-off-by: Ola Jeppsson <ola@adapteva.com>